### PR TITLE
fix: do not throw error for undefined auto-imports in composables

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -77,6 +77,11 @@ module.exports = {
       // Pages and layouts are required to have a single root element if transitions are enabled.
       files: ['**/pages/**/*.{js,ts,jsx,tsx,vue}', '**/layouts/**/*.{js,ts,jsx,tsx,vue}'],
       rules: { 'vue/no-multiple-template-root': 'error' }
+    },
+    {
+      // Composables can use auto-imports, eslint should not throw an error for undefined
+      files: ['**/composables/**/*.{js,ts,jsx,tsx,vue}'],
+      rules: { 'no-undef': 'off' }
     }
   ]
 }


### PR DESCRIPTION
This is an attempt to solve #314, about auto-imports marked as errors in composables.

This seemed to be kinda straightforward, but it is the first time that I try to contribute to this repo, so please let me know if there is something that should be changed or improved.

