### PR TITLE
fix(eslint-config): handle `app.vue` and `error.vue` in custom `srcDir`

### DIFF
--- a/packages/eslint-config/src/flat/configs/disables.ts
+++ b/packages/eslint-config/src/flat/configs/disables.ts
@@ -8,9 +8,9 @@ export default function disables(options: NuxtESLintConfigOptions): FlatConfig[]
 
   const fileRoutes = [
     // These files must have one-word names as they have a special meaning in Nuxt.
-    ...dirs.layers?.flatMap((layersDir) => [
+    ...dirs.layers?.flatMap(layersDir => [
       join(layersDir, `app.${GLOB_EXTS}`),
-      join(layersDir, `error.${GLOB_EXTS}`)
+      join(layersDir, `error.${GLOB_EXTS}`),
     ]) || [],
 
     // Layouts and pages are not used directly by users so they can have one-word names.

--- a/packages/eslint-config/src/flat/configs/disables.ts
+++ b/packages/eslint-config/src/flat/configs/disables.ts
@@ -7,8 +7,11 @@ export default function disables(options: NuxtESLintConfigOptions): FlatConfig[]
   const nestedGlobPattern = `**/*.${GLOB_EXTS}`
 
   const fileRoutes = [
-    relative(dirs.src || '', `app.${GLOB_EXTS}`),
-    relative(dirs.src || '', `error.${GLOB_EXTS}`),
+    // These files must have one-word names as they have a special meaning in Nuxt.
+    ...dirs.layers?.flatMap((layersDir) => [
+      join(layersDir, `app.${GLOB_EXTS}`),
+      join(layersDir, `error.${GLOB_EXTS}`)
+    ]) || [],
 
     // Layouts and pages are not used directly by users so they can have one-word names.
     ...(dirs.layouts?.map(layoutsDir => join(layoutsDir, nestedGlobPattern)) || []),

--- a/packages/eslint-config/src/flat/configs/disables.ts
+++ b/packages/eslint-config/src/flat/configs/disables.ts
@@ -1,4 +1,4 @@
-import { join, relative } from 'pathe'
+import { join } from 'pathe'
 import { GLOB_EXTS } from '../constants'
 import type { FlatConfig, NuxtESLintConfigOptions } from '../types'
 


### PR DESCRIPTION
context: https://github.com/danielroe/roe.dev/commit/3baf8d44c5a4b30c7e3c69daab4d7ab3ff27a087#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R20-R25