### PR TITLE
feat(eslint-config): support for multiple src dirs and auto infer directories structure

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,30 +6,22 @@ export default createConfigForNuxt({
     stylistic: true,
   },
   dirs: {
-    src: 'playground',
-    pages: [
-      'playground/pages',
-      'docs/pages',
-    ],
-    layouts: [
-      'playground/layouts',
-      'docs/layouts',
-    ],
-    components: [
-      'playground/components',
-      'docs/components',
+    src: [
+      'playground',
+      'docs',
     ],
   },
-}).append(
-  {
-    ignores: [
-      'packages-legacy/**',
-    ],
-  },
-  {
-    files: ['docs/**/*.vue'],
-    rules: {
-      'vue/no-v-html': 'off',
+})
+  .append(
+    {
+      ignores: [
+        'packages-legacy/**',
+      ],
     },
-  },
-)
+    {
+      files: ['docs/**/*.vue'],
+      rules: {
+        'vue/no-v-html': 'off',
+      },
+    },
+  )

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@eslint/js": "^8.57.0",
     "@nuxt/eslint-plugin": "workspace:*",
-    "@rushstack/eslint-patch": "^1.9.0",
+    "@rushstack/eslint-patch": "^1.10.1",
     "@stylistic/eslint-plugin": "^1.7.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",

--- a/packages/eslint-config/src/flat/configs/disables.ts
+++ b/packages/eslint-config/src/flat/configs/disables.ts
@@ -2,24 +2,26 @@ import { join } from 'pathe'
 import { GLOB_EXTS } from '../constants'
 import type { NuxtESLintConfigOptions } from '../types'
 import type { FlatConfigItem } from 'eslint-flat-config-utils'
+import { resolveOptions } from '../utils'
 
 export default function disables(options: NuxtESLintConfigOptions): FlatConfigItem[] {
-  const dirs = options.dirs ?? {}
+  const resolved = resolveOptions(options)
+  const dirs = resolved.dirs
   const nestedGlobPattern = `**/*.${GLOB_EXTS}`
 
   const fileRoutes = [
     // These files must have one-word names as they have a special meaning in Nuxt.
-    ...dirs.layers?.flatMap(layersDir => [
+    ...dirs.src.flatMap(layersDir => [
       join(layersDir, `app.${GLOB_EXTS}`),
       join(layersDir, `error.${GLOB_EXTS}`),
     ]) || [],
 
     // Layouts and pages are not used directly by users so they can have one-word names.
-    ...(dirs.layouts?.map(layoutsDir => join(layoutsDir, nestedGlobPattern)) || []),
-    ...(dirs.pages?.map(pagesDir => join(pagesDir, nestedGlobPattern)) || []),
+    ...(dirs.layouts.map(layoutsDir => join(layoutsDir, nestedGlobPattern)) || []),
+    ...(dirs.pages.map(pagesDir => join(pagesDir, nestedGlobPattern)) || []),
 
     // These files should have multiple words in their names as they are within subdirectories.
-    ...(dirs.components?.map(componentsDir => join(componentsDir, '*', nestedGlobPattern)) || []),
+    ...(dirs.components.map(componentsDir => join(componentsDir, '*', nestedGlobPattern)) || []),
   ]
 
   const configs: FlatConfigItem[] = []

--- a/packages/eslint-config/src/flat/configs/nuxt.ts
+++ b/packages/eslint-config/src/flat/configs/nuxt.ts
@@ -3,9 +3,11 @@ import type { NuxtESLintConfigOptions } from '../types'
 import nuxtPlugin from '@nuxt/eslint-plugin'
 import { GLOB_EXTS } from '../constants'
 import type { FlatConfigItem } from 'eslint-flat-config-utils'
+import { resolveOptions } from '../utils'
 
 export default function nuxt(options: NuxtESLintConfigOptions): FlatConfigItem[] {
-  const dirs = options.dirs ?? {}
+  const resolved = resolveOptions(options)
+  const dirs = resolved.dirs
 
   const fileSingleRoot = [
     ...(dirs.layouts?.map(layoutsDir => join(layoutsDir, `**/*.${GLOB_EXTS}`)) || []),

--- a/packages/eslint-config/src/flat/configs/vue.ts
+++ b/packages/eslint-config/src/flat/configs/vue.ts
@@ -4,10 +4,12 @@ import * as parserTs from '@typescript-eslint/parser'
 // @ts-expect-error missing types
 import pluginVue from 'eslint-plugin-vue'
 import type { NuxtESLintConfigOptions } from '../types'
-import { removeUndefined } from '../utils'
+import { removeUndefined, resolveOptions } from '../utils'
 import type { FlatConfigItem } from 'eslint-flat-config-utils'
 
 export default function vue(options: NuxtESLintConfigOptions): FlatConfigItem[] {
+  const resolved = resolveOptions(options)
+
   return [
     {
       name: 'nuxt:setup-vue',
@@ -92,7 +94,7 @@ export default function vue(options: NuxtESLintConfigOptions): FlatConfigItem[] 
         'prefer-spread': 'error', // ts transpiles spread to apply, so no need for manual apply
         'valid-typeof': 'off', // ts(2367)
 
-        ...(options.features?.stylistic
+        ...(resolved.features.stylistic
           ? {}
           : {
               // Disable Vue's default stylistic rules when stylistic is not enabled

--- a/packages/eslint-config/src/flat/index.ts
+++ b/packages/eslint-config/src/flat/index.ts
@@ -9,6 +9,7 @@ import stylistic from './configs/stylistic'
 import type { FlatConfigItem, ResolvableFlatConfig } from 'eslint-flat-config-utils'
 import { FlatConfigPipeline } from 'eslint-flat-config-utils'
 import { pipe } from 'eslint-flat-config-utils'
+import { resolveOptions } from './utils'
 
 export * from './types'
 
@@ -34,24 +35,26 @@ export function defineFlatConfigs(
 export function createConfigForNuxt(options: NuxtESLintConfigOptions = {}): FlatConfigPipeline<FlatConfigItem> {
   const pipeline = pipe()
 
-  if (options.features?.standalone !== false) {
+  const resolved = resolveOptions(options)
+
+  if (resolved.features.standalone !== false) {
     pipeline.append(
       base(),
       javascript(),
       typescript(),
-      vue(options),
+      vue(resolved),
     )
   }
 
-  if (options.features?.stylistic) {
+  if (resolved.features.stylistic) {
     pipeline.append(
-      stylistic(options.features.stylistic === true ? {} : options.features.stylistic),
+      stylistic(resolved.features.stylistic === true ? {} : resolved.features.stylistic),
     )
   }
 
   pipeline.append(
-    nuxt(options),
-    disables(options),
+    nuxt(resolved),
+    disables(resolved),
   )
 
   return pipeline

--- a/packages/eslint-config/src/flat/types.ts
+++ b/packages/eslint-config/src/flat/types.ts
@@ -26,7 +26,12 @@ export interface NuxtESLintConfigOptions {
     /**
      * Nuxt source directory
      */
-    src?: string
+    src?: string[]
+
+    /**
+     * Root directory for nuxt project
+     */
+    root?: string[]
 
     /**
      * Directory for pages
@@ -67,12 +72,14 @@ export interface NuxtESLintConfigOptions {
      * Directory for server
      */
     servers?: string[]
-
-    /**
-     * Directory for layers
-     */
-    layers?: string[]
   }
+}
+
+type NotNill<T> = T extends null | undefined ? never : T
+
+export interface NuxtESLintConfigOptionsResolved {
+  features: Required<NotNill<NuxtESLintFeaturesOptions>>
+  dirs: Required<NotNill<NuxtESLintConfigOptions['dirs']>>
 }
 
 export type Awaitable<T> = T | Promise<T>

--- a/packages/eslint-config/src/flat/utils.ts
+++ b/packages/eslint-config/src/flat/utils.ts
@@ -1,3 +1,41 @@
+import type { NuxtESLintConfigOptions, NuxtESLintConfigOptionsResolved } from '../flat'
+
 export function removeUndefined<T extends object>(obj: T): T {
   return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined)) as T
+}
+
+export function resolveOptions(
+  config: NuxtESLintConfigOptions,
+): NuxtESLintConfigOptionsResolved {
+  if ('__resolved' in config) {
+    return config as NuxtESLintConfigOptionsResolved
+  }
+
+  const dirs = {
+    ...config.dirs,
+  } as NuxtESLintConfigOptionsResolved['dirs']
+
+  dirs.root ||= [process.cwd()]
+  dirs.src ||= dirs.root
+  dirs.pages ||= dirs.src.map(src => `${src}/pages`)
+  dirs.layouts ||= dirs.src.map(src => `${src}/layouts`)
+  dirs.components ||= dirs.src.map(src => `${src}/components`)
+  dirs.composables ||= dirs.src.map(src => `${src}/composables`)
+  dirs.plugins ||= dirs.src.map(src => `${src}/plugins`)
+  dirs.modules ||= dirs.src.map(src => `${src}/modules`)
+  dirs.middleware ||= dirs.src.map(src => `${src}/middleware`)
+  dirs.servers ||= dirs.src.map(src => `${src}/servers`)
+
+  const resolved: NuxtESLintConfigOptionsResolved = {
+    features: {
+      standalone: true,
+      stylistic: false,
+      ...config.features,
+    },
+    dirs,
+  }
+
+  Object.defineProperty(resolved, '__resolved', { value: true, enumerable: false })
+
+  return resolved
 }

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -54,8 +54,8 @@
     "@nuxt/kit": "^3.11.1",
     "chokidar": "^3.6.0",
     "eslint-flat-config-utils": "^0.1.2",
-    "eslint-flat-config-viewer": "^0.1.14",
-    "eslint-typegen": "^0.1.5",
+    "eslint-flat-config-viewer": "^0.1.20",
+    "eslint-typegen": "^0.1.6",
     "get-port-please": "^3.1.2",
     "pathe": "^1.1.2",
     "unimport": "^3.7.1"

--- a/packages/module/src/modules/config.ts
+++ b/packages/module/src/modules/config.ts
@@ -203,15 +203,15 @@ function getDirs(nuxt: Nuxt): NuxtESLintConfigOptions['dirs'] {
     plugins: [],
     middleware: [],
     modules: [],
-    layers: [],
     servers: [],
-    src: nuxt.options.srcDir,
+    root: [nuxt.options.rootDir],
+    src: [nuxt.options.srcDir],
   }
 
   for (const layer of nuxt.options._layers) {
     const r = (t: string) => relative(nuxt.options.rootDir, resolve(layer.config.srcDir, t))
 
-    dirs.layers.push(r(''))
+    dirs.src.push(r(''))
     dirs.pages.push(r(nuxt.options.dir.pages || 'pages'))
     dirs.layouts.push(r(nuxt.options.dir.layouts || 'layouts'))
     dirs.plugins.push(r(nuxt.options.dir.plugins || 'plugins'))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-plugin
       '@rushstack/eslint-patch':
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^1.10.1
+        version: 1.10.1
       '@stylistic/eslint-plugin':
         specifier: ^1.7.0
         version: 1.7.0(eslint@8.57.0)(typescript@5.4.3)
@@ -176,11 +176,11 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       eslint-flat-config-viewer:
-        specifier: ^0.1.14
-        version: 0.1.14(eslint@8.57.0)(typescript@5.4.3)
+        specifier: ^0.1.20
+        version: 0.1.20(eslint@8.57.0)(typescript@5.4.3)
       eslint-typegen:
-        specifier: ^0.1.5
-        version: 0.1.5
+        specifier: ^0.1.6
+        version: 0.1.6
       get-port-please:
         specifier: ^3.1.2
         version: 3.1.2
@@ -1477,7 +1477,7 @@ packages:
       jiti: 1.21.0
       mri: 1.2.0
       nanoid: 4.0.2
-      ofetch: 1.3.3
+      ofetch: 1.3.4
       parse-git-config: 3.0.0
       pathe: 1.1.2
       rc9: 2.1.1
@@ -1503,7 +1503,7 @@ packages:
       jiti: 1.21.0
       mri: 1.2.0
       nanoid: 4.0.2
-      ofetch: 1.3.3
+      ofetch: 1.3.4
       parse-git-config: 3.0.0
       pathe: 1.1.2
       rc9: 2.1.1
@@ -2147,8 +2147,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rushstack/eslint-patch@1.9.0:
-    resolution: {integrity: sha512-AAWymnpvHbGty1BmgbdfbqQDboXs6xN6h2yAacO4yKVyyUUBnpYkp+P9jjPrV9zrAGw7JVVriRtGOHPInnfjZQ==}
+  /@rushstack/eslint-patch@1.10.1:
+    resolution: {integrity: sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg==}
     dev: false
 
   /@sigstore/bundle@2.2.0:
@@ -2558,22 +2558,49 @@ packages:
       '@unhead/schema': 1.8.20
       '@unhead/shared': 1.8.20
 
+  /@unhead/dom@1.9.3:
+    resolution: {integrity: sha512-l7KO6zv8T/yKpWOtcKww3k6RLENEiwiapoiPwtKlwWBFJekSjgM1+1AVu58yWqadFYHGP0/XhMwxKrOaOL+Vkw==}
+    dependencies:
+      '@unhead/schema': 1.9.3
+      '@unhead/shared': 1.9.3
+    dev: false
+
   /@unhead/schema@1.8.20:
     resolution: {integrity: sha512-n0e5jsKino8JTHc4wpr4l8MXXIrj0muYYAEVa0WSYkIVnMiBr1Ik3l6elhCr4fdSyJ3M2DQQleea/oZCr11XCw==}
     dependencies:
       hookable: 5.5.3
       zhead: 2.2.4
 
+  /@unhead/schema@1.9.3:
+    resolution: {integrity: sha512-emFHDYxn6u5SVwSRXMpYBCYKBua+GCjUwTLLdUupInthW3UraSUuXakmv06wDvejE8pTrBOPrGWescIYmwm69A==}
+    dependencies:
+      hookable: 5.5.3
+      zhead: 2.2.4
+    dev: false
+
   /@unhead/shared@1.8.20:
     resolution: {integrity: sha512-J0fdtavcMtXcG0g9jmVW03toqfr8A0G7k+Q6jdpwuUPhWk/vhfZn3aiRV+F8LlU91c/AbGWDv8T1MrtMQbb0Sg==}
     dependencies:
       '@unhead/schema': 1.8.20
+
+  /@unhead/shared@1.9.3:
+    resolution: {integrity: sha512-9wJ+wNmAVDCsCFKE3YHMwNkmFqKzCqQfp53ABJHQFOvY336s4nMWtiMNMjxF4aY4pJk8Qpwd8dRlgpLlyH0KZg==}
+    dependencies:
+      '@unhead/schema': 1.9.3
+    dev: false
 
   /@unhead/ssr@1.8.20:
     resolution: {integrity: sha512-Cq1NcdYZ/IAkJ0muqdOBxJXb5dn+uV+RvIXDykRb9lGgriU/S0fzUw8XYTYMwLlvW6rSMrtRx319hz2D3ZrBkA==}
     dependencies:
       '@unhead/schema': 1.8.20
       '@unhead/shared': 1.8.20
+
+  /@unhead/ssr@1.9.3:
+    resolution: {integrity: sha512-oFFynkmAoHoDU2uG3otBnYOj5rmi14fqaUpA4tzsRlyLiwyF3Hd8nXec9YM7JaBzstoiy2NGf7dTfY7eNc8NoQ==}
+    dependencies:
+      '@unhead/schema': 1.9.3
+      '@unhead/shared': 1.9.3
+    dev: false
 
   /@unhead/vue@1.8.20(vue@3.4.21):
     resolution: {integrity: sha512-Lm6cnbX/QGCh+pxGN1Tl6LVXxYs5bLlN8APfI2rQ5kMNRE6Yy7r2eY5wCZ0SfsSRonqJxzVlgMMh8JPEY5d4GQ==}
@@ -4204,24 +4231,25 @@ packages:
       '@types/eslint': 8.56.6
     dev: false
 
-  /eslint-flat-config-viewer@0.1.14(eslint@8.57.0)(typescript@5.4.3):
-    resolution: {integrity: sha512-2ErHkowC7N9jiLHYAEI7lrm9phEPkyuZTCbRjVmj3B9yk/zVHhLCSlPGWzkgAEDW2MQRGSkvlbbhD7C9FRhYXQ==}
+  /eslint-flat-config-viewer@0.1.20(eslint@8.57.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-TYYsH8k4b/P7JDaPfAMo362QaEHE4vTQh5UNrJ9/ZBzGxjpb6ESOTM1Gaij5SP+59YwY6ETJDWmaMnbi9qmLpA==}
     hasBin: true
     peerDependencies:
       eslint: ^8.50.0
     dependencies:
-      '@unhead/shared': 1.8.20
-      '@unhead/ssr': 1.8.20
+      '@unhead/shared': 1.9.3
+      '@unhead/ssr': 1.9.3
       chokidar: 3.6.0
       consola: 3.2.3
       devalue: 4.3.2
       eslint: 8.57.0
+      fast-glob: 3.3.2
       get-port-please: 3.1.2
       jiti: 1.21.0
-      minimatch: 9.0.3
-      ofetch: 1.3.3
+      minimatch: 9.0.4
+      ofetch: 1.3.4
       open: 10.1.0
-      unhead: 1.8.20
+      unhead: 1.9.3
       vue: 3.4.21(typescript@5.4.3)
       vue-bundle-renderer: 2.0.0
       ws: 8.16.0
@@ -4431,8 +4459,8 @@ packages:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  /eslint-typegen@0.1.5:
-    resolution: {integrity: sha512-b178DT9jEdX/BsMCzO6JQzd/MFAHs1ruCrlXkPFQJP4OOkenqnlQJ+8jh1Maq3uHc3PQ8EQFPusRCxuVTy4CpQ==}
+  /eslint-typegen@0.1.6:
+    resolution: {integrity: sha512-M6a9l3ifdZvZIJahUQmf1c1gVxoNu9e8E1Uwzu3bg2jKH1dfSkO8KSViNio54vEQCvyVPfJky5U246hZf4j1RA==}
     dependencies:
       '@types/eslint': 8.56.6
       json-schema-to-typescript-lite: 14.0.0
@@ -4595,7 +4623,7 @@ packages:
       enhanced-resolve: 5.15.0
       mlly: 1.6.1
       pathe: 1.1.2
-      ufo: 1.5.2
+      ufo: 1.5.3
 
   /fake-indexeddb@5.0.2:
     resolution: {integrity: sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==}
@@ -5592,7 +5620,7 @@ packages:
       node-forge: 1.3.1
       pathe: 1.1.2
       std-env: 3.7.0
-      ufo: 1.5.2
+      ufo: 1.5.3
       untun: 0.1.3
       uqr: 0.1.2
     transitivePeerDependencies:
@@ -5781,6 +5809,13 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
+
+  /minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -5981,7 +6016,7 @@ packages:
       mlly: 1.6.1
       mri: 1.2.0
       node-fetch-native: 1.6.2
-      ofetch: 1.3.3
+      ofetch: 1.3.4
       ohash: 1.1.3
       openapi-typescript: 6.7.5
       pathe: 1.1.2
@@ -6029,6 +6064,9 @@ packages:
 
   /node-fetch-native@1.6.2:
     resolution: {integrity: sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==}
+
+  /node-fetch-native@1.6.4:
+    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
 
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -6486,6 +6524,13 @@ packages:
       destr: 2.0.3
       node-fetch-native: 1.6.2
       ufo: 1.5.2
+
+  /ofetch@1.3.4:
+    resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
+    dependencies:
+      destr: 2.0.3
+      node-fetch-native: 1.6.4
+      ufo: 1.5.3
 
   /ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
@@ -7985,6 +8030,9 @@ packages:
   /ufo@1.5.2:
     resolution: {integrity: sha512-eiutMaL0J2MKdhcOM1tUy13pIrYnyR87fEd8STJQFrrAwImwvlXkxlZEjaKah8r2viPohld08lt73QfLG1NxMg==}
 
+  /ufo@1.5.3:
+    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
+
   /ultrahtml@1.5.3:
     resolution: {integrity: sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg==}
 
@@ -8072,6 +8120,15 @@ packages:
       '@unhead/schema': 1.8.20
       '@unhead/shared': 1.8.20
       hookable: 5.5.3
+
+  /unhead@1.9.3:
+    resolution: {integrity: sha512-nV6d4ALJph73hCJT1tAd4z30Q2Gv8vNUvK0netM/EetL2scdggf9brcX3OyPqWhZbnFIOE+AouH2oE1KPznkcw==}
+    dependencies:
+      '@unhead/dom': 1.9.3
+      '@unhead/schema': 1.9.3
+      '@unhead/shared': 1.9.3
+      hookable: 5.5.3
+    dev: false
 
   /unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -8246,7 +8303,7 @@ packages:
       lru-cache: 10.2.0
       mri: 1.2.0
       node-fetch-native: 1.6.2
-      ofetch: 1.3.3
+      ofetch: 1.3.4
       ufo: 1.5.2
     transitivePeerDependencies:
       - uWebSockets.js
@@ -8631,7 +8688,7 @@ packages:
   /vue-bundle-renderer@2.0.0:
     resolution: {integrity: sha512-oYATTQyh8XVkUWe2kaKxhxKVuuzK2Qcehe+yr3bGiaQAhK3ry2kYE4FWOfL+KO3hVFwCdLmzDQTzYhTi9C+R2A==}
     dependencies:
-      ufo: 1.5.2
+      ufo: 1.5.3
 
   /vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}


### PR DESCRIPTION
This would allow direct configure usage easier by auto inferring the subfolder with Nuxt 3's default. Later for nuxt 4 we could have an option for different defaults.