### PR TITLE
fix: add `name` field to `@stylistic/eslint-plugin` configuration

### DIFF
--- a/packages/eslint-config/src/flat/index.ts
+++ b/packages/eslint-config/src/flat/index.ts
@@ -48,8 +48,12 @@ export function createConfigForNuxt(options: NuxtESLintConfigOptions = {}): Flat
 
   if (resolved.features.stylistic) {
     c.append({
-      name: 'nuxt:stylistic',
-      ...stylistic(resolved.features.stylistic === true ? {} : resolved.features.stylistic),
+      name: 'nuxt/stylistic',
+      ...stylistic(
+        resolved.features.stylistic === true
+          ? {}
+          : resolved.features.stylistic,
+      ),
     })
   }
 

--- a/packages/eslint-config/src/flat/index.ts
+++ b/packages/eslint-config/src/flat/index.ts
@@ -47,9 +47,10 @@ export function createConfigForNuxt(options: NuxtESLintConfigOptions = {}): Flat
   }
 
   if (resolved.features.stylistic) {
-    c.append(
-      stylistic(resolved.features.stylistic === true ? {} : resolved.features.stylistic),
-    )
+    c.append({
+      name: 'nuxt:stylistic',
+      ...stylistic(resolved.features.stylistic === true ? {} : resolved.features.stylistic),
+    })
   }
 
   c.append(


### PR DESCRIPTION
This pull request introduces the implementation of the proposed `name` field within the `@stylistic/eslint-plugin` configuration, addressing the [feature request](https://github.com/nuxt/eslint/issues/373) for enhanced configuration clarity and simplicity. By integrating a `name` field, we enable users to directly and intuitively identify and modify the configuration.

**Changes Made:**
- Added a `name` field to the configuration objects within `@stylistic/eslint-plugin`, allowing for straightforward identification.

**Benefits:**
- **Improved Clarity:** Directly identifying configurations by name enhances the understandability of the configuration process.
- **Reduced Complexity:** Eliminates the need to inspect the plugins array, simplifying the configuration adjustment steps.
- **Enhanced Developer Experience:** Streamlines the process of modifying ESLint rules, making it more accessible and less error-prone.

**Examples:**
The following code snippet illustrates how a configuration named `nuxt:stylistic` can now be easily modified:

```javascript
import { createConfigForNuxt, defineFlatConfigs } from '@nuxt/eslint-config/flat'

export default defineFlatConfigs(
  createConfigForNuxt().then((configs) => {
    return configs.map((config) => {
      return config.name === 'nuxt:stylistic'
        ? {
            ...config,
            rules: {
              ...config.rules,
              // Rule configuration here…
            },
          }
        : config
    })
  }),
)
```

I look forward to your feedback and any further suggestions for improvement.