### PR TITLE
feat(eslint-plugin) new rule: require `@since` annotations

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,5 +33,8 @@
   "dependencies": {
     "@typescript-eslint/types": "^7.7.0",
     "@typescript-eslint/utils": "^7.7.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/rule-tester": "^7.7.0"
   }
 }

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,5 +1,7 @@
 import { rule as preferImportMetaRule } from './prefer-import-meta'
+import { rule as requireJsdocSinceRule } from './require-jsdoc-since'
 
 export default {
   'prefer-import-meta': preferImportMetaRule,
+  'require-jsdoc-since': requireJsdocSinceRule,
 }

--- a/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
+++ b/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
@@ -28,7 +28,7 @@ export const rule = createRule<MessageIds, Options>({
         const declarationType = exportNode.declaration?.type
         if (declarationType === 'TSInterfaceDeclaration' || declarationType === 'TSTypeAliasDeclaration') return
 
-        // TODO: Check if it's an override, and the function above has a valid JSDoc
+        // TODO: Check if it's an overload, and the function above has a valid JSDoc
 
         // Check if the exported node has a leading comment
         const leadingComments = context.sourceCode.getCommentsBefore(exportNode)

--- a/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
+++ b/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
@@ -9,11 +9,11 @@ export const rule = createRule<MessageIds, Options>({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Require @since tag in JSDoc comment.',
+      description: 'Require `@since` tag in JSDoc comment.',
     },
     schema: [],
     messages: {
-      default: 'Missing @since tag in JSDoc comment.',
+      default: 'Missing `@since` tag in JSDoc comment.',
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
+++ b/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
@@ -1,0 +1,39 @@
+import { createRule } from '../utils'
+
+type MessageIds = 'default'
+
+type Options = []
+
+export const rule = createRule<MessageIds, Options>({
+  name: 'prefer-import-meta',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require @since tag in JSDoc comment.',
+    },
+    schema: [],
+    messages: {
+      default: 'Missing @since tag in JSDoc comment.',
+    },
+  },
+  defaultOptions: [],
+  create: context => ({
+    Program: function (node) {
+      const sourceCode = context.sourceCode
+      const comments = sourceCode.getAllComments()
+
+      comments.forEach((comment) => {
+        if (comment.type === 'Block' && comment.value.startsWith('*')) {
+          const jsdoc = comment.value.replace(/^\/\*\*|\*\/$/g, '')
+          console.warn(jsdoc)
+          if (!jsdoc.includes('@since')) {
+            context.report({
+              messageId: 'default',
+              node,
+            })
+          }
+        }
+      })
+    },
+  }),
+})

--- a/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
+++ b/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
@@ -5,7 +5,7 @@ type MessageIds = 'noSince' | 'noJSDoc'
 type Options = []
 
 export const rule = createRule<MessageIds, Options>({
-  name: 'prefer-import-meta',
+  name: 'require-jsdoc-since',
   meta: {
     type: 'problem',
     docs: {

--- a/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
+++ b/packages/eslint-plugin/src/rules/require-jsdoc-since/index.ts
@@ -1,6 +1,6 @@
 import { createRule } from '../utils'
 
-type MessageIds = 'default'
+type MessageIds = 'noSince' | 'noJSDoc'
 
 type Options = []
 
@@ -13,23 +13,44 @@ export const rule = createRule<MessageIds, Options>({
     },
     schema: [],
     messages: {
-      default: 'Missing `@since` tag in JSDoc comment.',
+      noSince: 'Missing `@since` tag in JSDoc comment.',
+      noJSDoc: 'Missing JSDoc comment.',
     },
   },
   defaultOptions: [],
   create: context => ({
     Program: function (node) {
-      const sourceCode = context.sourceCode
-      const comments = sourceCode.getAllComments()
+      // Filter only named and default exports
+      const onlyExported = node.body.filter(node => node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration')
 
-      comments.forEach((comment) => {
-        if (comment.type === 'Block' && comment.value.startsWith('*')) {
-          const jsdoc = comment.value.replace(/^\/\*\*|\*\/$/g, '')
-          console.warn(jsdoc)
-          if (!jsdoc.includes('@since')) {
+      onlyExported.forEach((exportNode) => {
+        // Filter out interfaces and type aliases
+        const declarationType = exportNode.declaration?.type
+        if (declarationType === 'TSInterfaceDeclaration' || declarationType === 'TSTypeAliasDeclaration') return
+
+        // TODO: Check if it's an override, and the function above has a valid JSDoc
+
+        // Check if the exported node has a leading comment
+        const leadingComments = context.sourceCode.getCommentsBefore(exportNode)
+        if (!leadingComments.length) {
+          // No leading comment, report missing JSDoc
+          context.report({
+            messageId: 'noJSDoc',
+            node: exportNode,
+            loc: exportNode.loc,
+          })
+        }
+        else {
+          // Check if the leading comment has a valid JSDoc
+          const hasValidJsDoc = leadingComments.some((comment) => {
+            return comment.type === 'Block' && comment.value.startsWith('*') && comment.value.includes('@since')
+          })
+
+          if (!hasValidJsDoc) {
             context.report({
-              messageId: 'default',
-              node,
+              messageId: 'noSince',
+              node: exportNode,
+              loc: leadingComments[0].loc,
             })
           }
         }

--- a/packages/eslint-plugin/tests/require-since.test.ts
+++ b/packages/eslint-plugin/tests/require-since.test.ts
@@ -1,11 +1,9 @@
 import { RuleTester } from '@typescript-eslint/rule-tester'
 import { rule } from '../src/rules/require-jsdoc-since'
 
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-})
+const ruleTester = new RuleTester()
 
-ruleTester.run('require-since', rule, {
+ruleTester.run('require-jsdoc-since', rule, {
   valid: [
     {
       code: `
@@ -17,28 +15,28 @@ ruleTester.run('require-since', rule, {
       code: `
         /**
          * @since 1.0.0
-        */
+         */
         function foo() {}
     `,
-    // TODO: Check overloads
     },
     {
       code: `
         /**
          * This is a comment.
-         * @param {string} foo - This is a foo.
+         * @param {string} bar - This is a bar.
          * @since 1.0.0
          */
         function foo(bar) {}
-        `,
+      `,
     },
+    // TODO: Check overloads
   ],
   invalid: [
     {
       code: `
         /**
          * This is a comment.
-         * @param {string} foo - This is a foo.
+         * @param {string} bar - This is a bar.
          */
         function foo(bar) {}
         `,

--- a/packages/eslint-plugin/tests/require-since.test.ts
+++ b/packages/eslint-plugin/tests/require-since.test.ts
@@ -1,0 +1,52 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import { rule } from '../src/rules/require-jsdoc-since'
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('require-since', rule, {
+  valid: [
+    {
+      code: `
+        /** @since 1.0.0 */
+        function foo() {}
+    `,
+    },
+    {
+      code: `
+        /**
+         * @since 1.0.0
+        */
+        function foo() {}
+    `,
+    // TODO: Check overloads
+    },
+    {
+      code: `
+        /**
+         * This is a comment.
+         * @param {string} foo - This is a foo.
+         * @since 1.0.0
+         */
+        function foo(bar) {}
+        `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        /**
+         * This is a comment.
+         * @param {string} foo - This is a foo.
+         */
+        function foo(bar) {}
+        `,
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: `function foo() {}`,
+      errors: [{ messageId: 'missing' }],
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,10 @@ importers:
       eslint:
         specifier: ^8.57.0 || ^9.0.0
         version: 9.0.0
+    devDependencies:
+      '@typescript-eslint/rule-tester':
+        specifier: ^7.7.0
+        version: 7.7.0(@eslint/eslintrc@3.0.2)(eslint@9.0.0)(typescript@5.4.5)
 
   packages/module:
     dependencies:
@@ -1368,6 +1372,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@typescript-eslint/rule-tester@7.7.0':
+    resolution: {integrity: sha512-DWsSFnjR9XBLjYkHNh7/NEKRz1v9qE2GfR4qQqimh3IiHHOspyE67NiUy8Ydyxe2dyKFl7akiqJb5iVcwfzX/g==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@eslint/eslintrc': '>=2'
+      eslint: ^8.56.0
 
   '@typescript-eslint/scope-manager@6.21.0':
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
@@ -6696,6 +6707,19 @@ snapshots:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/rule-tester@7.7.0(@eslint/eslintrc@3.0.2)(eslint@9.0.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint/eslintrc': 3.0.2
+      '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.7.0(eslint@9.0.0)(typescript@5.4.5)
+      ajv: 6.12.6
+      eslint: 9.0.0
+      lodash.merge: 4.6.2
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@typescript-eslint/scope-manager@6.21.0':
     dependencies:


### PR DESCRIPTION
Hi there! This is work towards resolving https://github.com/nuxt/nuxt/issues/24950. This PR adds a new rule: `require-jsdoc-since`. The purpose of this rule is to check exported functions and make sure they have a JSDoc with a `@since` annotation. 

### Methodology
* Filter only `ExportNamedDeclaration` and `ExportDefaultDeclaration`
* Filter out `TSInterfaceDeclaration` and `TSTypeAliasDeclaration`
* Get leading comments
  * If there are none, then report missing JSDoc
* Check for a valid JSDOC with `@since` annotation
  * If there is none then report missing annotation

### Issues
Because it is looping over all definitions and checking individually, it is not aware of overloads. This leads to cases where a JSDoc defines a function with overloads, but the new rule reports that the overloads are missing valid JSDoc comments. 

Any help would be appreciated 😄  

### Development
I have made the following modifications to my local copy of Nuxt to test this. If there is a better way to integrate te types, please let me know as I'll need to make a PR to integrate this into Nuxt next :)

```js 
// eslint.config.mjs
// ...
  .override('nuxt/rules', {
    files: [
      // Here we define which files get checked
      'packages/*/src/utils.ts',
      'packages/nuxt/src/app/composables/*.ts',
      'packages/nuxt/src/app/utils.ts',
    ],
    rules: {
      // Override removed this default. 
      // Is there a better way to do this?
      'nuxt/prefer-import-meta': 'error',
      'nuxt/require-jsdoc-since': 'error',
    },
  })
// ...
  ```

```jsonc
// package.json
{
  // ...
 "resolutions": {
    // ...
    "@nuxt/eslint-plugin": "../eslint/packages/eslint-plugin",
    // ...                           ^ My local copy
  }
  // ...
}

```

### Testing
I have created a test file, but I have absolutely no idea how to run it. I would appreciate it if anyone could help 😃 
