### PR TITLE
docs: clarify when config will be generated

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -35,7 +35,7 @@ Run the following command to add the `@nuxt/eslint` module to your project:
 npx nuxi module add eslint
 ```
 
-Start your Nuxt app, a `eslint.config.mjs` file will be generated under your project root. You can customize it as needed.
+Once you start your Nuxt app, a `eslint.config.mjs` file will be generated under your project root. You can customize it as needed.
 
 ### Manual Setup
 


### PR DESCRIPTION
This PR makes it clear that the `eslint.config.mjs` file will be generated only once app is started with `nuxi prepare` or `nuxi dev`, and not right away when you run `npx nuxi module add eslint`.

Resolves https://github.com/nuxt/eslint/issues/422#issuecomment-2102653538