### PR TITLE
docs(config): add `ESLint Stylistic` in `@nuxt/eslint-config`

### DIFF
--- a/docs/content/1.packages/1.config.md
+++ b/docs/content/1.packages/1.config.md
@@ -153,7 +153,7 @@ You might also want to add a script entry to your `package.json`:
 
 ## ESLint Stylistic
 
-Similar to the [ESLint Module](https://eslint.nuxt.com/packages/module#eslint-stylistic), you can opt-in by setting features.stylistic to true in the eslint module options.
+Similar to the [ESLint Module](https://eslint.nuxt.com/packages/module#eslint-stylistic), you can opt-in by setting `stylistic` to `true` in the `features` module options.
 
 ```js [eslint.config.mjs]
 import { createConfigForNuxt } from '@nuxt/eslint-config/flat'

--- a/docs/content/1.packages/1.config.md
+++ b/docs/content/1.packages/1.config.md
@@ -150,3 +150,19 @@ You might also want to add a script entry to your `package.json`:
   }
 }
 ```
+
+## ESLint Stylistic
+
+Similar to the [ESLint Module](https://eslint.nuxt.com/packages/module#eslint-stylistic), you can opt-in by setting features.stylistic to true in the eslint module options.
+
+```js [eslint.config.mjs]
+import { createConfigForNuxt } from '@nuxt/eslint-config/flat'
+
+export default createConfigForNuxt({
+  features: {
+    stylistic: true // <---
+  }
+})
+```
+
+Learn more about all the available options in the [ESLint Stylistic documentation](https://eslint.style/guide/config-presets#configuration-factory).


### PR DESCRIPTION
### 🔗 Linked issue


### 📚 Description

ESLint Module docs has a section on ESLint Stylistic.
- https://eslint.nuxt.com/packages/module#eslint-stylistic

I thought it would be better to have a section for ESLint Stylistic in the `@nuxt/eslint-config` document with different ways to configure ESLint Stylistic.