### PR TITLE
fix(eslint-plugin): Added correct documentation URL

### DIFF
--- a/packages/eslint-plugin/src/rules/utils.ts
+++ b/packages/eslint-plugin/src/rules/utils.ts
@@ -8,7 +8,7 @@ export function createRule<
   rule: Readonly<ESLintUtils.RuleWithMetaAndName<TOptions, TMessageIds>>,
 ) {
   const _createRule = ESLintUtils.RuleCreator(
-    name => `https://eslint.nuxt.com/rules/${name}`,
+    name => `https://eslint.nuxt.com/packages/plugin#nuxt${name}`,
   )
   return _createRule(rule) as unknown as Rule.RuleModule
 }


### PR DESCRIPTION
When trying to open the docs through eslint inspector and others, it would redirect to

https://eslint.nuxt.com/rules/prefer-import-meta <- this returns a 404

So I modified to the correct URL
https://eslint.nuxt.com/packages/plugin#nuxtprefer-import-meta <- this works