### PR TITLE
docs: add example error message for standalone

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -252,7 +252,7 @@ export default defineNuxtConfig({
 })
 ```
 
-This ensures the module only generates Nuxt-specific rules so that you can merge it with your own config presets.
+This ensures the module only generates Nuxt-specific rules so that you can merge it with your own config presets. If this option is not changed, you can get errors like `ConfigError: Config "antfu/imports/rules": Key "plugins": Cannot redefine plugin "import".` 
 
 For example, with [`@antfu/eslint-config`](https://github.com/antfu/eslint-config):
 


### PR DESCRIPTION
I missed the standalone option. Had to learn the hard way.  By adding this error message to the docs I hope search engine indexing will help other people who did not read the docs correctly.