### PR TITLE
docs: update vscode-eslint info

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -90,11 +90,12 @@ export default withNuxt(
 
 ### VS Code
 
-Note that because ESLint Flat config is not yet enabled by default in the [ESLint VS Code extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), you will need to enable it via the `eslint.experimental.useFlatConfig` setting to get ESLint working. (This will likely not be needed after ESLint v9).
+ESLint v9.x support was added in the [ESLint VS Code extension (`vscode-eslint`)](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) v3.0.10.
+In versions of `vscode-eslint` prior to v3.0.10, the new configuration system is not enabled by default. To enable support for the new configuration files, edit your `.vscode/settings.json` file and add the following:
 
 ```json [.vscode/settings.json]
 {
-  // Enable ESlint flat config support
+  // Required in vscode-eslint < v3.0.10 only
   "eslint.experimental.useFlatConfig": true
 }
 ```


### PR DESCRIPTION
ESLint VSCode extension v3.0.10 has been released which enables flat config by default.