### PR TITLE
fix: remove unused dependencies

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "@eslint/js": "catalog:",
     "@nuxt/eslint-plugin": "workspace:*",
-    "@rushstack/eslint-patch": "catalog:",
     "@stylistic/eslint-plugin": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
@@ -67,7 +66,6 @@
     "globals": "catalog:",
     "local-pkg": "catalog:",
     "pathe": "catalog:",
-    "tslib": "catalog:",
     "vue-eslint-parser": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ catalogs:
     '@nuxt/test-utils':
       specifier: ^3.14.1
       version: 3.14.1
-    '@rushstack/eslint-patch':
-      specifier: ^1.10.4
-      version: 1.10.4
     '@stylistic/eslint-plugin':
       specifier: ^2.7.1
       version: 2.7.1
@@ -120,9 +117,6 @@ catalogs:
     taze:
       specifier: ^0.16.7
       version: 0.16.7
-    tslib:
-      specifier: ^2.7.0
-      version: 2.7.0
     typescript:
       specifier: ^5.5.4
       version: 5.5.4
@@ -249,9 +243,6 @@ importers:
       '@nuxt/eslint-plugin':
         specifier: workspace:*
         version: link:../eslint-plugin
-      '@rushstack/eslint-patch':
-        specifier: 'catalog:'
-        version: 1.10.4
       '@stylistic/eslint-plugin':
         specifier: 'catalog:'
         version: 2.7.1(eslint@9.9.1(jiti@1.21.6))(typescript@5.5.4)
@@ -291,9 +282,6 @@ importers:
       pathe:
         specifier: 'catalog:'
         version: 1.1.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.7.0
       vue-eslint-parser:
         specifier: 'catalog:'
         version: 9.4.3(eslint@9.9.1(jiti@1.21.6))
@@ -1823,9 +1811,6 @@ packages:
     resolution: {integrity: sha512-xGiIH95H1zU7naUyTKEyOA/I0aexNMUdO9qRv0bLKN3qu25bBdrxZHqA3PTJ24YNN/GdMzG4xkDcd/GvjuhfLg==}
     cpu: [x64]
     os: [win32]
-
-  '@rushstack/eslint-patch@1.10.4':
-    resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -7373,8 +7358,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.21.1':
     optional: true
-
-  '@rushstack/eslint-patch@1.10.4': {}
 
   '@sinclair/typebox@0.27.8': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,6 @@ catalog:
   '@nuxt/schema': ^3.13.0
   '@nuxt/test-utils': ^3.14.1
   '@nuxtjs/eslint-config': ^12.0.0
-  '@rushstack/eslint-patch': ^1.10.4
   '@stylistic/eslint-plugin': ^2.7.1
   '@types/eslint': ^9.6.1
   '@types/node': ^22.5.1
@@ -48,7 +47,6 @@ catalog:
   nuxt: ^3.13.0
   pathe: ^1.1.2
   taze: ^0.16.7
-  tslib: ^2.7.0
   typescript: ^5.5.4
   unimport: ^3.11.1
   vite-plugin-eslint2: ^4.4.0


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It looks like in `packages/eslint-config`, `@rushstack/eslint-patch` and `tslib` are unused. Those are added respectively in these commits:

- https://github.com/nuxt/eslint/commit/bf74ad93338cf0f6fb3938762ae2fd6fe1f73729: Used by `require('@rushstack/eslint-patch/modern-module-resolution')` but no longer exist now.
- https://github.com/nuxt/eslint/commit/d5f6f66bbcbc24cf785a3097485981dbfce3c1e6: Not sure why `tslib` was added, but it doesn't seem used in `dist` nor part of any deps' peer deps now.
