### PR TITLE
docs: remove experimental flag from flatlist eslint

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -117,7 +117,7 @@ In versions of `vscode-eslint` prior to v3.0.10, the new configuration system is
 ```json [.vscode/settings.json]
 {
   // Required in vscode-eslint < v3.0.10 only
-  "eslint.experimental.useFlatConfig": true
+  "eslint.useFlatConfig": true
 }
 ```
 


### PR DESCRIPTION
In latest versions this flag is not experimental anymore and might cause confusion.