### PR TITLE
fix(eslint-config): extend elements ignored by `vue/singleline-html-element-content-newline`

### DIFF
--- a/packages/eslint-config/src/flat/configs/vue.ts
+++ b/packages/eslint-config/src/flat/configs/vue.ts
@@ -130,6 +130,12 @@ export default async function vue(options: NuxtESLintConfigOptions): Promise<Lin
                 ignores: ['pre', 'textarea', 'router-link', 'RouterLink', 'nuxt-link', 'NuxtLink', 'u-link', 'ULink', ...INLINE_ELEMENTS],
                 allowEmptyLines: false,
               }],
+              'vue/singleline-html-element-content-newline': ['error', {
+                ignoreWhenNoAttributes: true,
+                ignoreWhenEmpty: true,
+                ignores: ['pre', 'textarea', 'router-link', 'RouterLink', 'nuxt-link', 'NuxtLink', 'u-link', 'ULink', ...INLINE_ELEMENTS],
+                externalIgnores: [],
+              }],
             }
           : {
               // Disable Vue's default stylistic rules when stylistic is not enabled


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Extends the list of ignored elements in the `vue/singleline-html-element-content-newline` rule to the same one as in https://github.com/nuxt/eslint/blob/cf92de1b586b9f91f57f39b1de53da846d205d80/packages/eslint-config/src/flat/configs/vue.ts#L128-L132