### PR TITLE
docs(install): specify --dev flag

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -32,7 +32,7 @@ Source code on GitHub
 Run the following command to add the `@nuxt/eslint` module to your project:
 
 ```bash [Terminal]
-npx nuxi module add eslint
+npx nuxi@latest module add eslint --dev
 ```
 
 Once you start your Nuxt app, a `eslint.config.mjs` file will be generated under your project root. You can customize it as needed.


### PR DESCRIPTION
### 🔗 Linked issue

Issue from the [nuxt/cli repository](https://github.com/nuxt/cli/issues/454)

### ❓ Type of change

Documentation

### 📚 Description

As of the [version 3.18](https://github.com/nuxt/cli/releases/tag/v3.18.0) of nuxt/cli, a `--dev` flag can be passed to `nuxi module` to specify a devDependency install for the module. I think we could use it for nuxt/eslint.
