### PR TITLE
docs: correct `import.meta.dev` typo

### DIFF
--- a/docs/content/1.packages/2.plugin.md
+++ b/docs/content/1.packages/2.plugin.md
@@ -21,7 +21,7 @@ Source code on GitHub
 
 ### `nuxt/prefer-import-meta`
 
-This rule enforces the use of `import.meta.dev` / `import.meta.server` in Nuxt 3 projects instead of `process.client` / `process.server`.
+This rule enforces the use of `import.meta.client` / `import.meta.server` in Nuxt 3 projects instead of `process.client` / `process.server`.
 
 ```json
 {


### PR DESCRIPTION
### 🔗 Linked issue

- closes #556 


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The result of correcting `process.client` should be `import.meta.client`, not `import.meta.dev`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
