### PR TITLE
docs: replace override rule module name

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -194,7 +194,7 @@ export default withNuxt(
     // ...Prepend some flat configs in front
   )
   // Override some rules in a specific config, based on their name
-  .override('nuxt/typescript', {
+  .override('nuxt/typescript/rules', {
     rules: {
       // ...Override rules, for example:
       '@typescript-eslint/ban-types': 'off'

--- a/docs/content/1.packages/1.config.md
+++ b/docs/content/1.packages/1.config.md
@@ -73,7 +73,7 @@ export default createConfigForNuxt({
     // ...Prepend some flat configs in front
   )
   // Override some rules in a specific config, based on their name
-  .override('nuxt/typescript', {
+  .override('nuxt/typescript/rules', {
     rules: {
       // ...Override rules, for example:
       '@typescript-eslint/ban-types': 'off'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #574 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes the documentation examples where the ESLint config override refers to `nuxt/typescript`. Based on the implementation, the correct reference should be `nuxt/typescript/rules` for properly overriding TypeScript-related rules.

The change affects:
- Module documentation in `docs/content/1.packages/0.module.md`
- Config documentation in `docs/content/1.packages/1.config.md`

This small correction ensures that users can correctly customize their TypeScript rules when following the examples in the documentation.