### PR TITLE
fix: sort imports objects by from + name

### DIFF
--- a/packages/module/src/modules/config/addons/globals.ts
+++ b/packages/module/src/modules/config/addons/globals.ts
@@ -20,7 +20,7 @@ export function createAddonGlobals(nuxt: Nuxt): ESLintConfigGenAddon {
       const imports = [
         ...await unimport?.getImports() || [],
         ...await nitroUnimport?.getImports() || [],
-      ].sort()
+      ].sort((a, b) => 10 * a.from.localeCompare(b.from) + a.name.localeCompare(b.name))
 
       return {
         configs: [


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

spotted this when trying out the deno node runner (which threw an error) - I'm not sure the previous `.sort()` was doing anything