### PR TITLE
fix: add `node:` prefix to build-in modules

### DIFF
--- a/packages/module/src/modules/config/generate.ts
+++ b/packages/module/src/modules/config/generate.ts
@@ -73,9 +73,11 @@ export async function generateESLintConfig(
   const imports = await Promise.all(importLines.map(async (line): Promise<Import> => {
     return {
       ...line,
-      from: (line.from.match(/^\w+:/) || builtinModules.includes(line.from))
-        ? line.from
-        : relativeWithDot(await r.resolvePath(line.from)),
+      from: builtinModules.includes(line.from)
+        ? line.from.replace(/^(node:)?/, 'node:')
+        : line.from.match(/^\w+:/)
+          ? line.from
+          : relativeWithDot(await r.resolvePath(line.from)),
     }
   }))
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

spotted this when running with deno as well