### PR TITLE
fix(eslint-config): add file type restrictions to prevent CSS parsing errors

### DIFF
--- a/packages/eslint-config/src/configs-tooling/jsdoc.ts
+++ b/packages/eslint-config/src/configs-tooling/jsdoc.ts
@@ -1,5 +1,6 @@
 import type { Linter } from 'eslint'
 import jsdocPlugin from 'eslint-plugin-jsdoc'
+import { GLOB_SRC, GLOB_VUE } from '../globs'
 import { resolveOptions } from '../utils'
 import type { NuxtESLintConfigOptions } from '../types'
 
@@ -9,6 +10,7 @@ export default function jsdoc(options: NuxtESLintConfigOptions = {}): Linter.Con
   return [
     {
       name: 'nuxt/tooling/jsdoc',
+      files: [GLOB_SRC, GLOB_VUE],
       plugins: {
         jsdoc: jsdocPlugin,
       },

--- a/packages/eslint-config/src/configs-tooling/regexp.ts
+++ b/packages/eslint-config/src/configs-tooling/regexp.ts
@@ -1,11 +1,13 @@
 import type { Linter } from 'eslint'
 import { configs } from 'eslint-plugin-regexp'
+import { GLOB_SRC, GLOB_VUE } from '../globs'
 
 export default function regexp(): Linter.Config[] {
   return [
     {
       ...configs['flat/recommended'] as Linter.Config,
       name: 'nuxt/tooling/regexp',
+      files: [GLOB_SRC, GLOB_VUE],
     },
   ]
 }

--- a/packages/eslint-config/src/configs-tooling/unicorn.ts
+++ b/packages/eslint-config/src/configs-tooling/unicorn.ts
@@ -1,10 +1,12 @@
 import pluginUnicorn from 'eslint-plugin-unicorn'
 import type { Linter } from 'eslint'
+import { GLOB_SRC, GLOB_VUE } from '../globs'
 
 export default function unicorn(): Linter.Config[] {
   return [
     {
       name: 'nuxt/tooling/unicorn',
+      files: [GLOB_SRC, GLOB_VUE],
       plugins: {
         unicorn: pluginUnicorn,
       },

--- a/packages/eslint-config/src/configs/stylistic.ts
+++ b/packages/eslint-config/src/configs/stylistic.ts
@@ -1,10 +1,12 @@
 import stylistic from '@stylistic/eslint-plugin'
 import type { StylisticCustomizeOptions } from '@stylistic/eslint-plugin'
 import type { Linter } from 'eslint'
+import { GLOB_SRC, GLOB_VUE } from '../globs'
 
 export default (options?: StylisticCustomizeOptions): Linter.Config => {
   return {
     name: 'nuxt/stylistic',
+    files: [GLOB_SRC, GLOB_VUE],
     ...stylistic.configs.customize(options) as Linter,
   }
 }

--- a/packages/eslint-config/test/__snapshots__/flat-compose.test.ts.snap
+++ b/packages/eslint-config/test/__snapshots__/flat-compose.test.ts.snap
@@ -299,6 +299,10 @@ exports[`flat config composition > with stylistic 1`] = `
     "name": "nuxt/sort-config",
   },
   {
+    "files": [
+      "**/*.?([cm])[jt]s?(x)",
+      "**/*.vue",
+    ],
     "name": "nuxt/stylistic",
   },
   {


### PR DESCRIPTION
## Summary

This PR fixes an issue where ESLint configurations were applying JavaScript/TypeScript-specific rules to CSS files, causing parsing errors.

## Problem

When using `@nuxt/eslint-config` with CSS files, ESLint would crash with errors like:
```
TypeError: Error while loading rule '@stylistic/indent': Cannot read properties of undefined (reading 'length')
Occurred while linting assets/css/main.css
```

This happens because several plugin configurations (regexp, stylistic, unicorn, jsdoc) don't specify which file types they should apply to, causing them to run on all files including CSS.

## Solution

Added explicit file type restrictions using the existing `GLOB_SRC` and `GLOB_VUE` patterns to ensure these plugins only apply to JavaScript, TypeScript, and Vue files:

- `GLOB_SRC`: `**/*.?([cm])[jt]s?(x)` (all JS/TS variants)
- `GLOB_VUE`: `**/*.vue` (Vue single-file components)

## Changes

- Added `files: [GLOB_SRC, GLOB_VUE]` to:
  - `configs-tooling/regexp.ts`
  - `configs-tooling/unicorn.ts`
  - `configs-tooling/jsdoc.ts`
  - `configs/stylistic.ts`

## Test Plan

- [x] Build the package successfully
- [x] Test with a Nuxt project that includes CSS files
- [x] Verify ESLint no longer crashes on CSS files
- [x] Ensure JS/TS/Vue files are still linted correctly

Fixes: https://github.com/poupe-ui/eslint-config/issues/138