### PR TITLE
fix(eslint-config): replace deprecated vue/object-property-newline option

### DIFF
--- a/packages/eslint-config/src/configs/vue.ts
+++ b/packages/eslint-config/src/configs/vue.ts
@@ -117,7 +117,7 @@ export default async function vue(options: NuxtESLintConfigOptions): Promise<Lin
               'vue/object-curly-spacing': ['error', 'always'],
               'vue/object-property-newline': [
                 'error',
-                { allowMultiplePropertiesPerLine: true },
+                { allowAllPropertiesOnSameLine: true },
               ],
               'vue/one-component-per-file': 'off',
               'vue/operator-linebreak': ['error', 'before'],


### PR DESCRIPTION
## Summary

This PR fixes a compatibility issue with eslint-plugin-vue v10+ by replacing the deprecated `allowMultiplePropertiesPerLine` option with the supported `allowAllPropertiesOnSameLine` option in the vue/object-property-newline rule configuration.

## Problem

When using @nuxt/eslint-config with eslint-plugin-vue v10+, users encounter the following error:

```
Error: eslint-plugin-vue error: 'vue/object-property-newline' rule has unknown option 'allowMultiplePropertiesPerLine'. Allowed options are: 'allowAllPropertiesOnSameLine'.
```

The current configuration uses the deprecated option:
- `allowMultiplePropertiesPerLine` - deprecated in eslint-plugin-vue v10.0.0
- `allowAllPropertiesOnSameLine` - the new supported option

## Solution

Updated the rule configuration to use only the supported option while maintaining the same formatting behavior.

## Test plan

- [x] Built the packages with `pnpm build`
- [x] Verified linting passes with `pnpm lint`
- [x] Tested playground linting with `pnpm lint:play`
- [x] Ensured the rule behavior remains the same (allowing multiple properties on the same line)