### PR TITLE
Fix favicon source

### DIFF
--- a/packages/module/src/modules/config/devtools.ts
+++ b/packages/module/src/modules/config/devtools.ts
@@ -71,7 +71,7 @@ export async function setupDevToolsIntegration(
     tabs.push({
       name: 'eslint-config',
       title: 'ESLint Config',
-      icon: 'https://raw.githubusercontent.com/eslint/config-inspector/main/app/public/favicon.svg',
+      icon: 'https://raw.githubusercontent.com/eslint/config-inspector/main/public/favicon.svg',
       view: viewerUrl
         ? {
             type: 'iframe',


### PR DESCRIPTION
### 🔗 Linked issue

none

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In devtools, Eslint icon is missing, removing /app from the url fixes the problem.
[Old](https://raw.githubusercontent.com/eslint/config-inspector/main/app/public/favicon.svg) -> [New](https://raw.githubusercontent.com/eslint/config-inspector/main/public/favicon.svg)
